### PR TITLE
Add auth placeholders and describe authentication flow

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,13 @@ Expose your career milestones via these clear, storytelling endpoints:
 * **Pattern:** MVC (models, services, controllers)
 * **Authentication:** OAuth2 / JWT (planned)
 
+## Authentication Flow (Planned)
+
+1. The client submits login credentials to an authentication endpoint and receives a signed token upon success.
+2. Each subsequent request includes the token in the `Authorization` header.
+3. Middleware or route dependencies verify the token's integrity and extract user information.
+4. Authorized requests proceed to the intended endpoint, while invalid or missing tokens result in an authentication error.
+
 ## Getting Started
 
 1. **Clone Repository**

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+# Placeholder: import authentication middleware or dependencies here
+# from app.auth import AuthMiddleware, get_current_user
+
+# Placeholder: add authentication middleware to the application
+# app.add_middleware(AuthMiddleware)
+
+# Placeholder: define authentication dependencies for route protection
+# async def get_current_user():
+#     """Retrieve the current user based on authentication token"""
+#     pass
+
+
+@app.get("/")
+def read_root():
+    """Simple root endpoint"""
+    return {"message": "Welcome to the storytelling API"}


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with placeholders for future auth middleware and dependencies
- document planned authentication flow in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892f0d88ae0832790ea711d3bfc0d62